### PR TITLE
Visualizing Percapita data on charts

### DIFF
--- a/docs/data/index.html
+++ b/docs/data/index.html
@@ -60,6 +60,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         //getTimelineChart(scope, chartVariable, entityId, showAll, chartText);
     });
+    document.querySelectorAll('input[name="whichPer"]').forEach((radio) => {
+    radio.addEventListener('change', () => {
+        refreshTimeline(); // This will re-fetch emissions and population and update the chart
+    });
+});
 });
 </script>
 
@@ -362,10 +367,10 @@ document.addEventListener('DOMContentLoaded', () => {
           <label> <input value="showBottom5" type="radio" name="whichLines" />Bottom 5 </label>
         </div>
 
-        <div id="perCapitaOptions" style="floatX:right">
+        <div id="perCapitaOptions" style="float:right">
             &nbsp; <span style="font-size:24px;color:#aaa">|</span> 
             <label> <input value="totals" type="radio" name="whichPer" checked  />Totals </label>
-            <label> <input value="percapita" type="radio" name="whichPer" />Per Capita (coming soon)</label>
+            <label> <input value="percapita" type="radio" name="whichPer" />Per Capita </label>
             <!--
             <label> <input value="perarea" type="radio" name="whichPer" />Per Area </label>
             -->

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -10,11 +10,11 @@ Scroll down to see Air and Water topics from our Google Sheet tabs.
 
 **Our UN Goal Timelines created with Google's JavaScript API**
 
-TO DO: Adjust the chartJS timeline above for mobile viewing on narrow screens.
+TO DO: Adjust the chartJS timeline above for mobile viewing on narrow screens. - Rakesh
 TO DO: Update our [Google Sheet UN Goal tabs](https://docs.google.com/spreadsheets/d/1IGyvcMV5wkGaIWM5dyB-vQIXXZFJUMV3WRf_UmyLkRk/edit?usp=sharing) with additional DCID values to pull into our javascript timelines above. - Everyone
 IN PROGRESS: Updates for top/bottom 5 and all countries - Priyanka
 IN PROGRESS: Goals sheets - Using one row to also support Age and Gender - Niranjan
-TO DO: Percapita needs to be applied to emissions timelines. And activate toggle.
+TO DO: Percapita needs to be applied to emissions timelines. And activate toggle. - Chandu
 STILL NEEDED?: Sort timeline data by year before sending it to the chart. Which charts did we see this issue in?
 
 TO DO: Update [RealityStream](/realitystream/models/) to fetch a path from our timelines page. The process will need to wait until the DOM is replaced with json. Sample path: [/data-commons/docs/data/#output=json](https://model.earth/data-commons/docs/data/#output=json)


### PR DESCRIPTION
This pull request introduces per capita support to the timeline visualizations in Data Commons charts. Users can now toggle between “Total” and “Per Capita” modes using a radio button. The charts dynamically adjust based on population data fetched

Key Changes
  - Added whichPer radio button group to toggle between "Total" and "Per Capita".
 -  Modified refreshTimeline() to:
      -  Read the selected whichPer mode (total or percapita).
      - Pass it to getTimelineChart() for consistent updates.
 - Updated getTimelineChart() to:
    - Fetch Count_Person population data from DataCommons API when percapita is selected.
    - Divide metric values by population for each observation date.
    - Adjust Y-axis label to reflect "per person" units.
  - Ensured charts are redrawn properly on toggle, with fallback behavior for missing population data.

